### PR TITLE
Animate header with fade-in and typewriter effect

### DIFF
--- a/index.html
+++ b/index.html
@@ -30,9 +30,9 @@
 </head>
 <body class="bg-slate-950 text-slate-100 min-h-screen">
   <!-- Top bar -->
-  <header class="sticky top-0 z-40 backdrop-blur border-b border-slate-800 bg-slate-950/70">
+  <header class="sticky top-0 z-40 backdrop-blur border-b border-slate-800 bg-slate-950/70 opacity-0 transition-opacity duration-1000">
     <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
-      <h1 class="text-xl font-semibold tracking-tight">My Dashboard</h1>
+      <h1 id="headerTitle" class="text-xl font-semibold tracking-tight">My Dashboard</h1>
       <nav class="flex items-center gap-2">
         <a href="index.html" class="px-3 py-1 rounded-lg hover:bg-slate-800 transition">Feed</a>
         <a href="library.html" class="px-3 py-1 rounded-lg hover:bg-slate-800 transition">Bookmarks</a>
@@ -71,7 +71,8 @@
     <p>Offline-ready. Data aggregated by GitHub Actions into <code>/data/feeds.json</code>.</p>
   </footer>
 
-  <script type="module" src="js/app.js"></script>
+    <script type="module" src="js/header.js"></script>
+    <script type="module" src="js/app.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {

--- a/js/header.js
+++ b/js/header.js
@@ -1,0 +1,21 @@
+document.addEventListener('DOMContentLoaded', () => {
+  const header = document.querySelector('header');
+  header?.classList.remove('opacity-0');
+  header?.classList.add('opacity-100');
+
+  const title = document.getElementById('headerTitle');
+  if (title) {
+    const text = title.textContent.trim();
+    title.textContent = '';
+    let i = 0;
+    const speed = 100;
+    function type() {
+      if (i < text.length) {
+        title.textContent += text.charAt(i);
+        i++;
+        setTimeout(type, speed);
+      }
+    }
+    type();
+  }
+});

--- a/library.html
+++ b/library.html
@@ -9,9 +9,9 @@
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-slate-950 text-slate-100 min-h-screen">
-  <header class="sticky top-0 z-40 backdrop-blur border-b border-slate-800 bg-slate-950/70">
+  <header class="sticky top-0 z-40 backdrop-blur border-b border-slate-800 bg-slate-950/70 opacity-0 transition-opacity duration-1000">
     <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
-      <h1 class="text-xl font-semibold tracking-tight">Bookmarks</h1>
+      <h1 id="headerTitle" class="text-xl font-semibold tracking-tight">Bookmarks</h1>
       <nav class="flex items-center gap-2">
         <a href="index.html" class="px-3 py-1 rounded-lg hover:bg-slate-800 transition">Feed</a>
         <a href="library.html" class="px-3 py-1 rounded-lg bg-slate-800">Bookmarks</a>
@@ -29,6 +29,7 @@
     </section>
   </main>
 
+  <script type="module" src="js/header.js"></script>
   <script type="module" src="js/library.js"></script>
   <script>
     if ('serviceWorker' in navigator) {


### PR DESCRIPTION
## Summary
- Fade in the header and type out the title like a typewriter
- Share header animation logic across pages via new `header.js`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bc50aa00388323b2211a04e9d3355c