### PR TITLE
feat: add Feeds page with OSINT/News filters

### DIFF
--- a/data/sources.json
+++ b/data/sources.json
@@ -1,41 +1,11 @@
 {
-  "topics": [
-    "World",
-    "Tech",
-    "Security",
-    "OSINT",
-    "Israel"
-  ],
+  "topics": ["OSINT", "News"],
   "sources": [
-    {
-      "name": "Reuters World",
-      "topic": "World",
-      "type": "rss",
-      "url": "https://www.reuters.com/world/rss"
-    },
-    {
-      "name": "Bellingcat",
-      "topic": "OSINT",
-      "type": "rss",
-      "url": "https://www.bellingcat.com/feed/"
-    },
-    {
-      "name": "Krebs on Security",
-      "topic": "Security",
-      "type": "rss",
-      "url": "https://krebsonsecurity.com/feed/"
-    },
-    {
-      "name": "r/osint",
-      "topic": "OSINT",
-      "type": "rss",
-      "url": "https://www.reddit.com/r/osint/.rss"
-    },
-    {
-      "name": "YouTube (example)",
-      "topic": "OSINT",
-      "type": "rss",
-      "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCxxxx"
-    }
+    { "name": "Bellingcat", "topic": "OSINT", "type": "rss", "url": "https://www.bellingcat.com/feed/" },
+    { "name": "OSINTCurio (YouTube)", "topic": "OSINT", "type": "rss", "url": "https://www.youtube.com/feeds/videos.xml?channel_id=UCxxxx" },
+    { "name": "r/osint", "topic": "OSINT", "type": "rss", "url": "https://www.reddit.com/r/osint/.rss" },
+    { "name": "Reuters World", "topic": "News", "type": "rss", "url": "https://www.reuters.com/world/rss" },
+    { "name": "Associated Press", "topic": "News", "type": "rss", "url": "https://apnews.com/hub/ap-top-news?utm_source=apnews.com&utm_medium=referral&utm_campaign=ap-rss&utm_content=topnews" },
+    { "name": "BBC World", "topic": "News", "type": "rss", "url": "http://feeds.bbci.co.uk/news/world/rss.xml" }
   ]
 }

--- a/feeds.html
+++ b/feeds.html
@@ -1,0 +1,128 @@
+<!doctype html>
+<html lang="en" class="h-full">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Feeds</title>
+  <meta name="theme-color" content="#0b1020" />
+  <link rel="manifest" href="manifest.webmanifest" />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;600;700;800&family=Plus+Jakarta+Sans:wght@400;600;800&display=swap" rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>
+    tailwind.config = {
+      theme: {
+        extend: {
+          fontFamily: { sans: ['Inter','system-ui','sans-serif'], display: ['Plus Jakarta Sans','Inter','system-ui','sans-serif'] }
+        }
+      }
+    }
+  </script>
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body class="h-full bg-ink text-slate-100">
+  <!-- Decorative background like index -->
+  <div aria-hidden="true" class="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
+    <div class="absolute -top-24 -left-24 w-96 h-96 rounded-full blur-3xl opacity-30 bg-gradient-to-tr from-indigo-500 via-cyan-400 to-emerald-400"></div>
+    <div class="absolute top-1/3 -right-24 w-[28rem] h-[28rem] rounded-full blur-3xl opacity-20 bg-gradient-to-tr from-fuchsia-500 via-rose-400 to-amber-300"></div>
+  </div>
+
+  <header class="sticky top-0 z-50 backdrop-blur border-b border-white/5 bg-black/30">
+    <div class="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+      <a href="index.html" class="text-xl font-display font-extrabold tracking-tight">
+        <span class="bg-gradient-to-r from-white via-cyan-200 to-indigo-300 bg-clip-text text-transparent">Feeds</span>
+      </a>
+      <nav class="hidden sm:flex items-center gap-2">
+        <a href="index.html" class="nav-chip">Feed</a>
+        <a href="feeds.html" class="nav-chip nav-chip--active">Feeds</a>
+        <a href="library.html" class="nav-chip">Bookmarks</a>
+        <button id="installBtn" class="btn-subtle">Install</button>
+      </nav>
+      <button id="hamburger" class="sm:hidden inline-flex items-center gap-2 rounded-xl px-3 py-2 border border-white/10 bg-white/5 hover:bg-white/10 transition">
+        <svg width="18" height="18" viewBox="0 0 24 24" class="opacity-90"><path fill="currentColor" d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4"/></svg>
+        <span class="text-sm">Menu</span>
+      </button>
+    </div>
+    <div id="menuOverlay" data-open="false" class="fixed inset-0 hidden">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
+      <div class="absolute right-3 top-3 w-[88%] sm:w-[420px] rounded-2xl border border-white/10 bg-gradient-to-b from-white/10 to-white/5 shadow-glow p-4 origin-top-right scale-95 opacity-0 transition-[opacity,transform] duration-200">
+        <div class="flex items-center justify-between">
+          <h2 class="font-display font-bold text-lg">Quick nav</h2>
+          <button id="menuClose" class="btn-subtle">Close</button>
+        </div>
+        <div class="mt-3 grid gap-2">
+          <a class="menu-item" href="index.html">Feed</a>
+          <a class="menu-item" href="feeds.html">Feeds</a>
+          <a class="menu-item" href="library.html">Bookmarks</a>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <main class="mx-auto max-w-6xl px-4 py-6 space-y-6">
+    <!-- Controls -->
+    <section class="flex flex-col md:flex-row md:items-end md:justify-between gap-3">
+      <div>
+        <h2 class="text-2xl font-display font-extrabold tracking-tight">Your feeds</h2>
+        <p id="lastRefreshed" class="text-sm text-slate-400">Last refreshed: —</p>
+      </div>
+      <div class="flex flex-wrap gap-2">
+        <div class="rounded-xl border border-white/10 bg-white/5 p-1">
+          <!-- Tabs -->
+          <button class="tab px-3 py-1.5 rounded-lg" data-topic="all">All</button>
+          <button class="tab px-3 py-1.5 rounded-lg" data-topic="OSINT">OSINT</button>
+          <button class="tab px-3 py-1.5 rounded-lg" data-topic="News">News</button>
+        </div>
+        <input id="search" placeholder="Search…" class="ui-input w-48 md:w-64" />
+        <select id="timeWindow" class="ui-select">
+          <option value="all">All time</option>
+          <option value="24h">Last 24h</option>
+          <option value="7d">Last 7 days</option>
+          <option value="30d">Last 30 days</option>
+        </select>
+        <select id="layoutMode" class="ui-select">
+          <option value="cards">Cards</option>
+          <option value="list">List</option>
+        </select>
+        <button id="reloadBtn" class="btn-primary">Reload</button>
+      </div>
+    </section>
+
+    <!-- Feed grid -->
+    <section id="feed" class="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+      <div class="skeleton-card"></div>
+    </section>
+
+    <!-- Configured sources (reads sources.json) -->
+    <section>
+      <div class="card-wrap">
+        <div class="card p-4">
+          <div class="flex items-center justify-between mb-3">
+            <h3 class="font-semibold">Configured Sources</h3>
+            <a id="actionsLink" target="_blank" rel="noopener"
+               class="btn-subtle"
+               href="https://github.com/__OWNER__/__REPO__/actions/workflows/fetch-feeds.yml">Open GitHub Actions</a>
+          </div>
+          <div id="sourcesList" class="grid gap-3 md:grid-cols-2"></div>
+          <p class="mt-3 text-xs text-slate-400">
+            Add or edit feeds in <code>/data/sources.json</code>. Each source has a <code>name</code>, <code>type</code> (rss), <code>url</code>, and <code>topic</code> (e.g., OSINT or News).
+          </p>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <div id="toastHost" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 space-y-2"></div>
+
+  <script type="module" src="js/ui.js"></script>
+  <script type="module" src="js/feeds.js"></script>
+  <script>
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', () => {
+        navigator.serviceWorker.register('service-worker.js').catch(console.error);
+      });
+    }
+  </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
   <link rel="icon" href="assets/icons/favicon.ico" />
   <link rel="apple-touch-icon" href="assets/icons/apple-touch-icon.png" />
   <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="stylesheet" href="styles.css" />
 
   <!-- Minimal modern CSS (no build step). Tailwind via CDN for fast styling. -->
   <script src="https://cdn.tailwindcss.com"></script>
@@ -30,14 +31,36 @@
 </head>
 <body class="bg-slate-950 text-slate-100 min-h-screen">
   <!-- Top bar -->
-  <header class="sticky top-0 z-40 backdrop-blur border-b border-slate-800 bg-slate-950/70 opacity-0 transition-opacity duration-1000">
-    <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
-      <h1 id="headerTitle" class="text-xl font-semibold tracking-tight">My Dashboard</h1>
-      <nav class="flex items-center gap-2">
-        <a href="index.html" class="px-3 py-1 rounded-lg hover:bg-slate-800 transition">Feed</a>
-        <a href="library.html" class="px-3 py-1 rounded-lg hover:bg-slate-800 transition">Bookmarks</a>
-        <button id="installBtn" class="px-3 py-1 rounded-lg bg-slate-800 hover:bg-slate-700 transition">Install</button>
+  <header class="sticky top-0 z-50 backdrop-blur border-b border-white/5 bg-black/30">
+    <div class="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+      <a href="index.html" class="text-xl font-display font-extrabold tracking-tight">
+        <span class="bg-gradient-to-r from-white via-cyan-200 to-indigo-300 bg-clip-text text-transparent">My Dashboard</span>
+      </a>
+      <nav class="hidden sm:flex items-center gap-2">
+        <a href="index.html" class="nav-chip nav-chip--active">Feed</a>
+        <a href="feeds.html" class="nav-chip">Feeds</a>
+        <a href="library.html" class="nav-chip">Bookmarks</a>
+        <button id="installBtn" class="btn-subtle">Install</button>
+        <button id="themeToggle" class="btn-subtle" title="Theme">Theme</button>
       </nav>
+      <button id="hamburger" class="sm:hidden inline-flex items-center gap-2 rounded-xl px-3 py-2 border border-white/10 bg-white/5 hover:bg-white/10 transition">
+        <svg width="18" height="18" viewBox="0 0 24 24" class="opacity-90"><path fill="currentColor" d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4"/></svg>
+        <span class="text-sm">Menu</span>
+      </button>
+    </div>
+    <div id="menuOverlay" data-open="false" class="fixed inset-0 hidden">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
+      <div class="absolute right-3 top-3 w-[88%] sm:w-[420px] rounded-2xl border border-white/10 bg-gradient-to-b from-white/10 to-white/5 shadow-glow p-4 origin-top-right scale-95 opacity-0 transition-[opacity,transform] duration-200">
+        <div class="flex items-center justify-between">
+          <h2 class="font-display font-bold text-lg">Quick nav</h2>
+          <button id="menuClose" class="btn-subtle">Close</button>
+        </div>
+        <div class="mt-3 grid gap-2">
+          <a class="menu-item" href="index.html">Feed</a>
+          <a class="menu-item" href="feeds.html">Feeds</a>
+          <a class="menu-item" href="library.html">Bookmarks</a>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -71,8 +94,10 @@
     <p>Offline-ready. Data aggregated by GitHub Actions into <code>/data/feeds.json</code>.</p>
   </footer>
 
-    <script type="module" src="js/header.js"></script>
-    <script type="module" src="js/app.js"></script>
+  <div id="toastHost" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 space-y-2"></div>
+
+  <script type="module" src="js/ui.js"></script>
+  <script type="module" src="js/app.js"></script>
   <script>
     if ('serviceWorker' in navigator) {
       window.addEventListener('load', () => {

--- a/js/feeds.js
+++ b/js/feeds.js
@@ -1,0 +1,178 @@
+import { toast } from './ui.js';
+
+const feedEl = document.getElementById('feed');
+const lastRefreshedEl = document.getElementById('lastRefreshed');
+const tabs = Array.from(document.querySelectorAll('.tab'));
+const searchEl = document.getElementById('search');
+const timeSel = document.getElementById('timeWindow');
+const layoutSel = document.getElementById('layoutMode');
+const reloadBtn = document.getElementById('reloadBtn');
+const sourcesList = document.getElementById('sourcesList');
+
+let RAW = [];
+let STATE = {
+  topic: 'all',
+  q: '',
+  time: 'all',
+  layout: localStorage.getItem('feeds_layout') || 'cards'
+};
+
+function withinWindow(dateIso, windowKey) {
+  if (!dateIso || windowKey === 'all') return true;
+  const d = new Date(dateIso).getTime();
+  const now = Date.now();
+  const days = windowKey === '24h' ? 1 : windowKey === '7d' ? 7 : 30;
+  return (now - d) <= days * 24 * 60 * 60 * 1000;
+}
+
+function setGrid() {
+  if (STATE.layout === 'list') {
+    feedEl.className = 'grid gap-3';
+  } else {
+    feedEl.className = 'grid gap-4 sm:grid-cols-2 lg:grid-cols-3';
+  }
+}
+
+function cardHtml(item) {
+  const img = item.image ? `<img src="${item.image}" alt="" class="w-full h-40 object-cover rounded-xl mb-3">` : '';
+  const t = item.title || 'Untitled';
+  const time = item.published_at ? new Date(item.published_at).toLocaleString() : '—';
+  return `
+    <div class="card-wrap hover:scale-[1.01] transition">
+      <article class="card p-3">
+        ${img}
+        <div class="flex items-center justify-between gap-3 mb-1">
+          <div class="flex items-center gap-2">
+            <span class="badge">${item.source || 'Source'}</span>
+            ${item.topic ? `<span class="badge">${item.topic}</span>`:''}
+          </div>
+          <div class="text-[11px] text-slate-400">${time}</div>
+        </div>
+        <h3 class="text-base font-semibold leading-snug">${t}</h3>
+        <p class="mt-1 text-sm text-slate-300 line-clamp-3">${item.summary || ''}</p>
+        <div class="mt-3">
+          <a href="${item.url}" target="_blank" rel="noopener" class="btn-subtle">Open</a>
+        </div>
+      </article>
+    </div>
+  `;
+}
+
+function rowHtml(item) {
+  const t = item.title || 'Untitled';
+  const time = item.published_at ? new Date(item.published_at).toLocaleString() : '—';
+  return `
+    <a href="${item.url}" target="_blank" rel="noopener" class="row">
+      <div class="w-12 h-12 rounded-lg bg-white/5 border border-white/10 flex items-center justify-center overflow-hidden">
+        ${item.image ? `<img src="${item.image}" class="w-full h-full object-cover">` : `<span class="text-sm">${(item.source||'•')[0]}</span>`}
+      </div>
+      <div class="min-w-0 flex-1">
+        <div class="flex items-center gap-2">
+          <span class="badge">${item.source || 'Source'}</span>
+          ${item.topic ? `<span class="badge">${item.topic}</span>`:''}
+        </div>
+        <div class="font-medium truncate">${t}</div>
+        <div class="text-xs text-slate-400">${time}</div>
+      </div>
+    </a>
+  `;
+}
+
+function render() {
+  setGrid();
+  const q = STATE.q.toLowerCase().trim();
+  let items = RAW.filter(it =>
+    (STATE.topic === 'all' || it.topic === STATE.topic) &&
+    withinWindow(it.published_at, STATE.time) &&
+    (!q || (it.title||'').toLowerCase().includes(q) || (it.summary||'').toLowerCase().includes(q) || (it.source||'').toLowerCase().includes(q))
+  );
+
+  feedEl.innerHTML = '';
+  if (!items.length) {
+    feedEl.innerHTML = `<div class="text-sm text-slate-300">No items match your filters.</div>`;
+    return;
+  }
+  if (STATE.layout === 'list') {
+    for (const it of items) feedEl.insertAdjacentHTML('beforeend', rowHtml(it));
+  } else {
+    for (const it of items) feedEl.insertAdjacentHTML('beforeend', cardHtml(it));
+  }
+}
+
+function skeletons(n=9) {
+  feedEl.innerHTML = '';
+  for (let i=0;i<n;i++) {
+    const d = document.createElement('div');
+    d.className = 'skeleton-card';
+    feedEl.appendChild(d);
+  }
+}
+
+async function loadFeed(showToast=true) {
+  try {
+    skeletons();
+    const res = await fetch('data/feeds.json', { cache: 'no-store' });
+    if (!res.ok) throw new Error('Failed to load feeds.json');
+    const data = await res.json();
+    RAW = data.items || [];
+    lastRefreshedEl.textContent = `Last refreshed: ${new Date(data.generated_at).toLocaleString()}`;
+    render();
+    if (showToast) toast('Feed updated');
+  } catch (e) {
+    console.error(e);
+    lastRefreshedEl.textContent = 'Failed to load feed.';
+    feedEl.innerHTML = `<div class="text-sm text-red-300">Could not load feed. Try again later.</div>`;
+  }
+}
+
+async function loadSources() {
+  try {
+    const res = await fetch('data/sources.json', { cache: 'no-store' });
+    if (!res.ok) return;
+    const data = await res.json();
+    const byTopic = {};
+    for (const s of (data.sources || [])) {
+      const t = s.topic || 'Other';
+      byTopic[t] = byTopic[t] || [];
+      byTopic[t].push(s);
+    }
+    sourcesList.innerHTML = '';
+    Object.keys(byTopic).sort().forEach(topic => {
+      const wrap = document.createElement('div');
+      wrap.className = 'rounded-2xl border border-white/10 bg-white/5 p-3';
+      wrap.innerHTML = `<div class="font-semibold mb-2">${topic}</div>`;
+      const ul = document.createElement('ul');
+      ul.className = 'space-y-1 text-sm text-slate-300';
+      byTopic[topic].forEach(s => {
+        const li = document.createElement('li');
+        li.innerHTML = `<span class="badge">${s.type || 'rss'}</span> <span class="ml-1">${s.name}</span>`;
+        ul.appendChild(li);
+      });
+      wrap.appendChild(ul);
+      sourcesList.appendChild(wrap);
+    });
+  } catch {}
+}
+
+// Events
+tabs.forEach(b => b.addEventListener('click', () => {
+  tabs.forEach(x => x.classList.remove('bg-white/15'));
+  b.classList.add('bg-white/15');
+  STATE.topic = b.dataset.topic;
+  localStorage.setItem('feeds_tab', STATE.topic);
+  render();
+}));
+searchEl?.addEventListener('input', e => { STATE.q = e.target.value; render(); });
+timeSel?.addEventListener('change', e => { STATE.time = e.target.value; render(); });
+layoutSel?.addEventListener('change', e => { STATE.layout = e.target.value; localStorage.setItem('feeds_layout', STATE.layout); render(); });
+reloadBtn?.addEventListener('click', () => loadFeed(true));
+
+// Init
+(() => {
+  const savedTab = localStorage.getItem('feeds_tab') || 'all';
+  const btn = tabs.find(t => t.dataset.topic === savedTab) || tabs[0];
+  btn?.click();
+  layoutSel.value = STATE.layout;
+})();
+loadFeed(false);
+loadSources();

--- a/js/ui.js
+++ b/js/ui.js
@@ -1,0 +1,55 @@
+export function toast(message, timeout = 3000) {
+  const host = document.getElementById('toastHost');
+  if (!host) return;
+  const div = document.createElement('div');
+  div.className = 'px-3 py-2 rounded-lg bg-slate-800 text-sm';
+  div.textContent = message;
+  host.appendChild(div);
+  setTimeout(() => div.remove(), timeout);
+}
+
+// Theme toggle
+const themeBtn = document.getElementById('themeToggle');
+if (themeBtn) {
+  themeBtn.addEventListener('click', () => {
+    const html = document.documentElement;
+    const current = html.getAttribute('data-theme') || 'dark';
+    const next = current === 'dark' ? 'light' : 'dark';
+    html.setAttribute('data-theme', next);
+    localStorage.setItem('theme', next);
+    toast(`Theme: ${next}`);
+  });
+  const saved = localStorage.getItem('theme');
+  if (saved) document.documentElement.setAttribute('data-theme', saved);
+}
+
+// Install PWA prompt
+let deferred;
+window.addEventListener('beforeinstallprompt', e => {
+  e.preventDefault();
+  deferred = e;
+  document.getElementById('installBtn')?.classList.remove('hidden');
+});
+const installBtn = document.getElementById('installBtn');
+installBtn?.addEventListener('click', async () => {
+  if (!deferred) return;
+  deferred.prompt();
+  await deferred.userChoice;
+  deferred = null;
+});
+
+// Mobile menu overlay
+const hamburger = document.getElementById('hamburger');
+const overlay = document.getElementById('menuOverlay');
+const closeBtn = document.getElementById('menuClose');
+function closeMenu() {
+  overlay?.classList.add('hidden');
+  overlay?.setAttribute('data-open', 'false');
+}
+function openMenu() {
+  overlay?.classList.remove('hidden');
+  overlay?.setAttribute('data-open', 'true');
+}
+hamburger?.addEventListener('click', openMenu);
+closeBtn?.addEventListener('click', closeMenu);
+overlay?.addEventListener('click', (e) => { if (e.target === overlay) closeMenu(); });

--- a/library.html
+++ b/library.html
@@ -6,16 +6,39 @@
   <title>My Library</title>
   <meta name="theme-color" content="#0f172a" />
   <link rel="manifest" href="manifest.webmanifest" />
+  <link rel="stylesheet" href="styles.css" />
   <script src="https://cdn.tailwindcss.com"></script>
 </head>
 <body class="bg-slate-950 text-slate-100 min-h-screen">
-  <header class="sticky top-0 z-40 backdrop-blur border-b border-slate-800 bg-slate-950/70 opacity-0 transition-opacity duration-1000">
-    <div class="mx-auto max-w-5xl px-4 py-3 flex items-center justify-between">
-      <h1 id="headerTitle" class="text-xl font-semibold tracking-tight">Bookmarks</h1>
-      <nav class="flex items-center gap-2">
-        <a href="index.html" class="px-3 py-1 rounded-lg hover:bg-slate-800 transition">Feed</a>
-        <a href="library.html" class="px-3 py-1 rounded-lg bg-slate-800">Bookmarks</a>
+  <header class="sticky top-0 z-50 backdrop-blur border-b border-white/5 bg-black/30">
+    <div class="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+      <a href="index.html" class="text-xl font-display font-extrabold tracking-tight">
+        <span class="bg-gradient-to-r from-white via-cyan-200 to-indigo-300 bg-clip-text text-transparent">Bookmarks</span>
+      </a>
+      <nav class="hidden sm:flex items-center gap-2">
+        <a href="index.html" class="nav-chip">Feed</a>
+        <a href="feeds.html" class="nav-chip">Feeds</a>
+        <a href="library.html" class="nav-chip nav-chip--active">Bookmarks</a>
+        <button id="installBtn" class="btn-subtle">Install</button>
       </nav>
+      <button id="hamburger" class="sm:hidden inline-flex items-center gap-2 rounded-xl px-3 py-2 border border-white/10 bg-white/5 hover:bg-white/10 transition">
+        <svg width="18" height="18" viewBox="0 0 24 24" class="opacity-90"><path fill="currentColor" d="M4 6h16v2H4zm0 5h16v2H4zm0 5h16v2H4"/></svg>
+        <span class="text-sm">Menu</span>
+      </button>
+    </div>
+    <div id="menuOverlay" data-open="false" class="fixed inset-0 hidden">
+      <div class="absolute inset-0 bg-black/60 backdrop-blur-sm"></div>
+      <div class="absolute right-3 top-3 w-[88%] sm:w-[420px] rounded-2xl border border-white/10 bg-gradient-to-b from-white/10 to-white/5 shadow-glow p-4 origin-top-right scale-95 opacity-0 transition-[opacity,transform] duration-200">
+        <div class="flex items-center justify-between">
+          <h2 class="font-display font-bold text-lg">Quick nav</h2>
+          <button id="menuClose" class="btn-subtle">Close</button>
+        </div>
+        <div class="mt-3 grid gap-2">
+          <a class="menu-item" href="index.html">Feed</a>
+          <a class="menu-item" href="feeds.html">Feeds</a>
+          <a class="menu-item" href="library.html">Bookmarks</a>
+        </div>
+      </div>
     </div>
   </header>
 
@@ -29,7 +52,9 @@
     </section>
   </main>
 
-  <script type="module" src="js/header.js"></script>
+  <div id="toastHost" class="fixed bottom-4 left-1/2 -translate-x-1/2 z-50 space-y-2"></div>
+
+  <script type="module" src="js/ui.js"></script>
   <script type="module" src="js/library.js"></script>
   <script>
     if ('serviceWorker' in navigator) {

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,20 +1,24 @@
-const CACHE = 'dash-cache-v1';
+const CACHE = 'dash-cache-v3';
 const CORE = [
   './',
   './index.html',
+  './feeds.html',
   './library.html',
+  './styles.css',
+  './js/ui.js',
   './js/app.js',
+  './js/feeds.js',
   './js/library.js',
   './manifest.webmanifest',
   './data/feeds.json',
-  './data/bookmarks.json'
+  './data/bookmarks.json',
+  './data/sources.json'
 ];
 
 self.addEventListener('install', (e) => {
   e.waitUntil(caches.open(CACHE).then(c => c.addAll(CORE)));
   self.skipWaiting();
 });
-
 self.addEventListener('activate', (e) => {
   e.waitUntil(
     caches.keys().then(keys =>
@@ -23,7 +27,6 @@ self.addEventListener('activate', (e) => {
   );
   self.clients.claim();
 });
-
 self.addEventListener('fetch', (e) => {
   const url = new URL(e.request.url);
   if (url.origin === location.origin) {

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,14 @@
+.nav-chip{padding:0.25rem 0.75rem;border-radius:0.75rem;background-color:rgba(255,255,255,0.05);font-size:0.875rem;}
+.nav-chip:hover{background-color:rgba(255,255,255,0.1);}
+.nav-chip--active{background-color:rgba(255,255,255,0.15);}
+.btn-subtle{padding:0.25rem 0.75rem;border-radius:0.75rem;background-color:rgba(255,255,255,0.05);font-size:0.875rem;}
+.btn-subtle:hover{background-color:rgba(255,255,255,0.1);}
+.btn-primary{padding:0.5rem 0.75rem;border-radius:0.75rem;background-color:#4f46e5;color:white;font-weight:500;}
+.btn-primary:hover{background-color:#6366f1;}
+.badge{display:inline-block;padding:0.125rem 0.5rem;border-radius:0.5rem;background-color:rgba(255,255,255,0.1);font-size:0.75rem;}
+.card{border:1px solid rgba(255,255,255,0.1);border-radius:1rem;background-color:rgba(255,255,255,0.05);}
+.card-wrap{transition:transform .2s;}
+.row{display:flex;align-items:center;gap:0.75rem;padding:0.5rem;border-radius:0.75rem;background-color:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);}
+.skeleton-card{height:10rem;border-radius:1rem;background-color:rgba(255,255,255,0.05);animation:skeleton 1.5s infinite ease-in-out;}
+@keyframes skeleton{0%{opacity:.6;}50%{opacity:.3;}100%{opacity:.6;}}
+.ui-input,.ui-select{padding:0.5rem;border-radius:0.5rem;background-color:rgba(255,255,255,0.05);border:1px solid rgba(255,255,255,0.1);color:white;}


### PR DESCRIPTION
## Summary
- create full Feeds page with OSINT and News tabs, layout and time filters, and sources panel
- add Feeds to site navigation and mobile menu
- cache new assets and sources in service worker

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run fetch:feeds` *(fetch failed for all sources; wrote 0 items)*

------
https://chatgpt.com/codex/tasks/task_e_68bd1bbe9c8c8323b2e2a0c3a9edfd79