### PR TITLE
chore(sources): add Israel news feeds

### DIFF
--- a/data/sources.json
+++ b/data/sources.json
@@ -1,9 +1,15 @@
 {
   "topics": [
-    "OSINT",
-    "News"
+    "News",
+    "OSINT"
   ],
   "sources": [
+    {
+      "name": "Al Jazeera — All News",
+      "topic": "News",
+      "type": "rss",
+      "url": "https://www.aljazeera.com/xml/rss/all.xml"
+    },
     {
       "name": "Associated Press",
       "topic": "News",
@@ -17,10 +23,46 @@
       "url": "http://feeds.bbci.co.uk/news/world/rss.xml"
     },
     {
+      "name": "Haaretz — All Headlines",
+      "topic": "News",
+      "type": "rss",
+      "url": "https://www.haaretz.com/cmlink/haaretz-com-all-headlines-rss-1.4605102"
+    },
+    {
+      "name": "Jerusalem Post — Breaking News",
+      "topic": "News",
+      "type": "rss",
+      "url": "https://www.jpost.com/rss/rssfeedsheadlines.aspx"
+    },
+    {
+      "name": "Jerusalem Post — Israel News",
+      "topic": "News",
+      "type": "rss",
+      "url": "https://www.jpost.com/rss/rssfeedsisraelnews.aspx"
+    },
+    {
       "name": "Reuters World",
       "topic": "News",
       "type": "rss",
       "url": "https://www.reuters.com/world/rss"
+    },
+    {
+      "name": "Start.me — 10 Mideast (page feed)",
+      "topic": "News",
+      "type": "rss",
+      "url": "https://start.me/p/9EQrXa/10-mideast.rss"
+    },
+    {
+      "name": "Times of Israel — All",
+      "topic": "News",
+      "type": "rss",
+      "url": "https://www.timesofisrael.com/feed/"
+    },
+    {
+      "name": "Ynet (HE) — Headlines",
+      "topic": "News",
+      "type": "rss",
+      "url": "http://www.ynet.co.il/Integration/StoryRss2.xml"
     },
     {
       "name": "Bellingcat",
@@ -47,6 +89,12 @@
       "url": "https://www.reddit.com/r/GreatOSINT/.rss"
     },
     {
+      "name": "r/PrivacySecurityOSINT (Reddit)",
+      "topic": "OSINT",
+      "type": "rss",
+      "url": "https://www.reddit.com/r/PrivacySecurityOSINT/.rss"
+    },
+    {
       "name": "r/osint",
       "topic": "OSINT",
       "type": "rss",
@@ -63,12 +111,6 @@
       "topic": "OSINT",
       "type": "rss",
       "url": "https://www.reddit.com/r/privacy/.rss"
-    },
-    {
-      "name": "r/PrivacySecurityOSINT (Reddit)",
-      "topic": "OSINT",
-      "type": "rss",
-      "url": "https://www.reddit.com/r/PrivacySecurityOSINT/.rss"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- add Israel-focused news RSS feeds (Start.me, Times of Israel, Jerusalem Post, Haaretz, Al Jazeera, Ynet)
- keep topics and sources deduped and sorted

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bd1f1372c48323badc903f91cd098d